### PR TITLE
Disallowing empty arrays

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -38,10 +38,10 @@ declare module 'discord.js' {
   {
     component?: MessageButton | MessageMenu | MessageActionRow;
     components?: MessageActionRow[];
-    button?: MessageButton | MessageButton[];
-    buttons?: MessageButton | MessageButton[];
-    menu?: MessageMenu | MessageMenu[];
-    menus?: MessageMenu | MessageMenu[];
+    button?: MessageButton | [MessageButton, ...MessageButton[]];
+    buttons?: MessageButton | [MessageButton, ...MessageButton[]];
+    menu?: MessageMenu | [MessageMenu, ...MessageMenu[]];
+    menus?: MessageMenu | [MessageMenu, ...MessageMenu[]];
   }
 
   export interface Message {


### PR DESCRIPTION
Disallowing empty arrays because if you provide an empty array to one of those 4 properties it will error out.

Error:
![grafik](https://user-images.githubusercontent.com/39440609/124662519-3da51380-dea9-11eb-80cc-bf9b22202991.png)
